### PR TITLE
fix for logo missing in customer docs site

### DIFF
--- a/customer-docs/user-manual.md
+++ b/customer-docs/user-manual.md
@@ -1,4 +1,4 @@
-![Streamliner Logo](../images/streamliner_logo.png)
+![Streamliner Logo](./images/streamliner_logo.png)
 
 - [Introduction](#introduction)
   * [Why Streamliner](#why-streamliner)


### PR DESCRIPTION
@satish-sanjeev we can keep this until new custemer-docs pull request merge. Once it merge, will break streamliner logo.