### PR TITLE
Support hive by upgrading schema crawler

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -11,7 +11,9 @@ isSnapshot := snapshot
 organization := "io.phdata.streamliner"
 scalaVersion := "2.12.12"
 
-val schemaCrawlerVersion = "16.2.5"
+val schemaCrawlerVersion = "16.12.3"
+scalacOptions += "-target:jvm-1.8"
+javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
 
 val excludeSlf4jBinding = ExclusionRule(organization = "org.slf4j")
 

--- a/src/it/scala/io/phdata/streamliner/schemacrawler/SchemaCrawlerImplIntegrationTest.scala
+++ b/src/it/scala/io/phdata/streamliner/schemacrawler/SchemaCrawlerImplIntegrationTest.scala
@@ -18,7 +18,7 @@ package io.phdata.streamliner.schemacrawler
 
 import java.io.File
 
-import io.phdata.streamliner.configuration.{Jdbc, SnowflakeUserDefinedTable, UserDefinedTable}
+import io.phdata.streamliner.configuration.Jdbc
 import org.scalatest.FunSuite
 
 /**

--- a/src/main/scala/io/phdata/streamliner/configuration/parser/JDBCParser.scala
+++ b/src/main/scala/io/phdata/streamliner/configuration/parser/JDBCParser.scala
@@ -17,7 +17,7 @@ object JDBCParser {
     val catalog = SchemaCrawlerImpl.getCatalog(jdbc, password)
 
     val tables =
-      catalog.getSchemas.asScala.find(s => s.getFullName.equals(jdbc.schema)) match {
+      catalog.getSchemas.asScala.find(s => s.getName.equals(jdbc.schema)) match {
         case Some(schema) =>
           val schemaCrawlerTables = catalog.getTables(schema).asScala.toList
           configuration.destination match {

--- a/src/main/scala/io/phdata/streamliner/schemacrawler/SchemaCrawlerImpl.scala
+++ b/src/main/scala/io/phdata/streamliner/schemacrawler/SchemaCrawlerImpl.scala
@@ -19,26 +19,23 @@ package io.phdata.streamliner.schemacrawler
 import java.nio.file.Paths
 import java.sql.Connection
 import java.util.logging.Level
-
-import io.phdata.streamliner.configuration.HadoopUserDefinedTable
 import io.phdata.streamliner.configuration.Jdbc
-import io.phdata.streamliner.configuration.SnowflakeUserDefinedTable
 import io.phdata.streamliner.util.FileUtil
 import org.apache.log4j.LogManager
+import schemacrawler.inclusionrule.RegularExpressionInclusionRule
 import schemacrawler.schema.Catalog
-import schemacrawler.schemacrawler.RegularExpressionInclusionRule
+import schemacrawler.schemacrawler.LimitOptionsBuilder
 import schemacrawler.schemacrawler.SchemaCrawlerOptions
 import schemacrawler.schemacrawler.SchemaCrawlerOptionsBuilder
-import schemacrawler.schemacrawler.SchemaInfoLevelBuilder
+import schemacrawler.tools.command.text.diagram.options.DiagramOutputFormat
+import schemacrawler.tools.command.text.schema.options.TextOutputFormat
 import schemacrawler.tools.databaseconnector.DatabaseConnectionSource
 import schemacrawler.tools.databaseconnector.SingleUseUserCredentials
 import schemacrawler.tools.executable.SchemaCrawlerExecutable
-import schemacrawler.tools.integration.graph.GraphOutputFormat
+import schemacrawler.tools.utility.SchemaCrawlerUtility
+import us.fatehi.utility.LoggingConfig
 import schemacrawler.tools.options.OutputFormat
 import schemacrawler.tools.options.OutputOptionsBuilder
-import schemacrawler.tools.options.TextOutputFormat
-import schemacrawler.utility.SchemaCrawlerUtility
-import sf.util.Utility.applyApplicationLogLevel
 
 import scala.collection.JavaConverters._
 
@@ -51,7 +48,7 @@ object SchemaCrawlerImpl extends FileUtil {
     execute(jdbc, password, TextOutputFormat.html, path, "schema.html")
 
   def getErdOutput(jdbc: Jdbc, password: String, path: String): Unit =
-    execute(jdbc, password, GraphOutputFormat.png, path, "schema.png")
+    execute(jdbc, password, DiagramOutputFormat.png, path, "schema.png")
 
   def execute(
       jdbc: Jdbc,
@@ -79,25 +76,35 @@ object SchemaCrawlerImpl extends FileUtil {
       case "INFO" => Level.INFO
       case "TRACE" => Level.FINER
       case _ => Level.ALL
-
     }
-    applyApplicationLogLevel(level)
+    new LoggingConfig(level)
   }
 
   private def getOptions(jdbc: Jdbc): SchemaCrawlerOptions = {
     setLogLevel()
-    val options = SchemaCrawlerOptionsBuilder
-      .builder()
-      .withSchemaInfoLevel(SchemaInfoLevelBuilder.standard())
-      .includeSchemas(new RegularExpressionInclusionRule(jdbc.schema))
-      .tableTypes(jdbc.tableTypes.asJava)
+
+    val options = SchemaCrawlerOptionsBuilder.newSchemaCrawlerOptions()
+    val limitOptionsBuilder = LimitOptionsBuilder.builder()
+    // latest version of schema crawler requires singular names
+    val tableTypes = jdbc.tableTypes
+      .map(i =>
+        i match {
+          case "tables" => "table"
+          case "views" => "view"
+          case s => s
+      })
+      .asJava
+    // schema crawler now names the objects differently, eg Hive."default"
+    limitOptionsBuilder
+      .includeSchemas(new RegularExpressionInclusionRule(s".*${jdbc.schema}.*"))
+      .tableTypes(tableTypes)
     jdbc.userDefinedTable match {
       case Some(tables) =>
-        val tableList = tables.map(t => s"${jdbc.schema}.${t.name}").mkString("|")
-        options.includeTables(new RegularExpressionInclusionRule(s"($tableList)"))
+        val tableList = tables.map(t => s".*${jdbc.schema}.*\\.${t.name}").mkString("|")
+        limitOptionsBuilder.includeTables(new RegularExpressionInclusionRule(s"($tableList)"))
       case None => // no-op
     }
-    options.toOptions
+    options.withLimitOptions(limitOptionsBuilder.toOptions)
   }
 
   private def getConnection(jdbc: Jdbc, password: String): Connection = {


### PR DESCRIPTION
Still need to understand if I should be stripping size and scale from the data type.

Should be replaced if Schema Crawler implements a hive
connector. However even in that case, if SC used the new
Hive Information Schema this would still be required for older
Hive installs.

Change-Id: I12f6acd75bd82a4275a87eee55e6d6c1d3a86d6f