### PR TITLE
STREAM-42 - Tweaks to schema evolution template

### DIFF
--- a/src/main/resources/templates/snowflake/shared/create-snowpipe-evolve-schema.ssp
+++ b/src/main/resources/templates/snowflake/shared/create-snowpipe-evolve-schema.ssp
@@ -72,8 +72,26 @@
         CALL streamliner_recreate_pipe('${table.destinationName}_pipe');
 
         DROP PROCEDURE streamliner_recreate_pipe(string);
+    #else
+        <%
+            templateContext.addError(s"Incompatible change in table ${destination.stagingDatabase.name}.${destination.stagingDatabase.schema}.${tableDiff.destinationName} which will be ignored")
+        %>
     #end
 #elseif (tableDiff.existsInSource && !tableDiff.existsInDestination)
-    <% render("../shared/create-snowpipe.ssp", Map("configuration" -> configuration, "table" -> table, "typeMapping" -> typeMapping))%>
-#end
 
+USE DATABASE ${destination.stagingDatabase.name};
+
+USE SCHEMA ${destination.stagingDatabase.schema};
+
+CREATE PIPE IF NOT EXISTS ${table.destinationName}_pipe
+    AUTO_INGEST = true
+#if (destination.snsTopic != null)
+    AWS_SNS_TOPIC = '${destination.snsTopic}'
+#end
+    AS
+	COPY INTO ${table.destinationName} (${unescape(table.columnList(null))})
+	    FROM ( SELECT ${unescape(sourceColumnStr)}
+		FROM @${configuration.name}_stage/${table.sourceName})
+	FILE_FORMAT = ( TYPE = PARQUET);
+
+#end

--- a/src/main/resources/templates/snowflake/shared/create-table-evolve-schema.ssp
+++ b/src/main/resources/templates/snowflake/shared/create-table-evolve-schema.ssp
@@ -10,7 +10,7 @@
 #if (tableDiff.existsInDestination && tableDiff.existsInSource)
     #if (tableDiff.allChangesAreCompatible())
         ALTER TABLE ${destination.stagingDatabase.name}.${destination.stagingDatabase.schema}.${tableDiff.destinationName} ADD COLUMN ${unescape(tableDiff.columnDDL(typeMapping))};
-    #elseif (!tableDiff.allChangesAreCompatible())
+    #else
         <%
             templateContext.addError(s"Incompatible change in table ${destination.stagingDatabase.name}.${destination.stagingDatabase.schema}.${tableDiff.destinationName} which will be ignored")
         %>

--- a/src/main/resources/templates/snowflake/snowflake-schema-evolution/Makefile.ssp
+++ b/src/main/resources/templates/snowflake/snowflake-schema-evolution/Makefile.ssp
@@ -11,13 +11,17 @@ create-table-evolve-schema: create-table-evolve-schema.sql
 copy-into: copy-into.sql
     $(snowsql-cmd) copy-into.sql
 
-create-pipe-evolve-schema: create-pipe-evolve-schema.sql
-    $(snowsql-cmd) create-pipe-evolve-schema.sql
+create-snowpipe-evolve-schema: create-snowpipe-evolve-schema.sql
+    $(snowsql-cmd) create-snowpipe-evolve-schema.sql
+
+first-run:
+    $(MAKE) create-table-evolve-schema
+    $(MAKE) create-snowpipe-evolve-schema
+    $(MAKE) copy-into
 
 run:
     $(MAKE) create-table-evolve-schema
-    $(MAKE) create-pipe-evolve-schema
-    $(MAKE) copy-into
+    $(MAKE) create-snowpipe-evolve-schema
 
 
 

--- a/src/main/resources/templates/snowflake/snowflake-schema-evolution/create-snowpipe-evolve-schema.ssp
+++ b/src/main/resources/templates/snowflake/snowflake-schema-evolution/create-snowpipe-evolve-schema.ssp
@@ -1,0 +1,9 @@
+#import(io.phdata.streamliner.schemadefiner.model.Snowflake)
+<%@ val configurationDiff: io.phdata.streamliner.schemadefiner.model.ConfigurationDiff %>
+<%@ val tableDiff: io.phdata.streamliner.schemadefiner.model.TableDiff %>
+<%@ val templateContext: io.phdata.streamliner.schemadefiner.model.TemplateContext %>
+<%@ val typeMapping: Map[String, Map[String, String]]%>
+#{
+    val destination = configurationDiff.currentDestination.asInstanceOf[Snowflake]
+}#
+<% render("../shared/create-snowpipe-evolve-schema.ssp", Map("configurationDiff" -> configurationDiff, "tableDiff" -> tableDiff, "typeMapping" -> typeMapping, "templateContext" -> templateContext))%>


### PR DESCRIPTION
* Output error in pipe template if table already exists but the change is incompatable
* Standardized the pipe creation template with the table creation template
* Remove redundant elseif in create-table-evolve-schema.ssp